### PR TITLE
Update inchi.rb

### DIFF
--- a/inchi.rb
+++ b/inchi.rb
@@ -24,9 +24,15 @@ end
 module Inchi
 
   def read_molfile(filename)
-    raise "Please provide a filename." if filename.nil?
-    raise "File `#{filename}` doesn't exist." unless File.exist?(filename)
-
+    if(filename.nil?)
+      print "\nPlease provide a filename.\n"
+      exit(false)
+    end
+    unless File.exist?(filename)
+      print "\n#{filename} doesn't exist.\n"
+      exit(false)
+    end
+    
     molfile = File.read(filename) # reads entire file and closes it
     molfile.split("\n")
   end


### PR DESCRIPTION
Allow for better error handling when either the filename does not exist or no argument at all is provided.

However, even with this modification code still not properly handled the case when the "--molfile" argument is provided but without a filename to follow (applies to my new version of program but should be the same with main branch):

\Ruby30-x64\bin\ruby.exe inchi_v2.1.rb --molfile
inchi_v2.1.rb:302:in `initialize': missing argument: --molfile (OptionParser::MissingArgument)
        from inchi_v2.1.rb:331:in `new'
        from inchi_v2.1.rb:331:in `<main>'