### PR TITLE
Refactor io module into a package

### DIFF
--- a/tests/io/test_molfile_reader.py
+++ b/tests/io/test_molfile_reader.py
@@ -1,12 +1,10 @@
 import pytest
-
-from tucan.io import (
+from tucan.io import graph_from_molfile_text, MolfileParserException
+from tucan.io.molfile_reader import (
+    _concat_lines_with_dash,
     _parse_atom_block_molfile3000,
     _parse_bond_block_molfile3000,
     _read_file,
-    MolfileParserException,
-    graph_from_molfile_text,
-    _concat_lines_with_dash,
 )
 
 

--- a/tests/parser/test_exception.py
+++ b/tests/parser/test_exception.py
@@ -1,6 +1,6 @@
 import re
 import pytest
-from tucan.parser.parser import TucanParserException, parse_tucan
+from tucan.io import TucanParserException, graph_from_tucan
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,6 @@ from tucan.parser.parser import TucanParserException, parse_tucan
         ),
     ],
 )
-def test_parse_tucan_error_msg(tucan, expected_error_msg):
+def test_graph_from_tucan_error_msg(tucan, expected_error_msg):
     with pytest.raises(TucanParserException, match=expected_error_msg):
-        parse_tucan(tucan)
+        graph_from_tucan(tucan)

--- a/tests/parser/test_grammar.py
+++ b/tests/parser/test_grammar.py
@@ -1,7 +1,7 @@
 import pytest
-
 from tucan.element_properties import element_symbols
-from tucan.parser.parser import _prepare_parser, TucanParserException, parse_tucan
+from tucan.io import TucanParserException, graph_from_tucan
+from tucan.parser.parser import _prepare_parser
 
 
 def _parse_sum_formula(s):
@@ -190,7 +190,7 @@ def test_cannot_parse_node_attributes(node_attributes):
     ],
 )
 def test_can_parse_tucan(tucan):
-    parse_tucan(tucan)
+    graph_from_tucan(tucan)
 
 
 @pytest.mark.parametrize(
@@ -203,4 +203,4 @@ def test_can_parse_tucan(tucan):
 )
 def test_cannot_parse_tucan(tucan):
     with pytest.raises(TucanParserException):
-        parse_tucan(tucan)
+        graph_from_tucan(tucan)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,13 +1,9 @@
 import re
 import pytest
 from tucan.canonicalization import canonicalize_molecule
+from tucan.io import graph_from_tucan, TucanParserException
 from tucan.serialization import serialize_molecule
-from tucan.parser.parser import (
-    _prepare_parser,
-    _walk_tree,
-    TucanParserException,
-    parse_tucan,
-)
+from tucan.parser.parser import _prepare_parser, _walk_tree
 
 
 def _extract_atoms_from_sum_formula(s):
@@ -203,8 +199,8 @@ def test_overriding_node_property_raises_exception(
         ),
     ],
 )
-def test_parse_tucan(tucan, expected_atoms, expected_bonds):
-    graph = parse_tucan(tucan)
+def test_graph_from_tucan(tucan, expected_atoms, expected_bonds):
+    graph = graph_from_tucan(tucan)
     assert dict(graph.nodes(data=True)) == expected_atoms
     assert list(graph.edges) == expected_bonds
 
@@ -223,9 +219,9 @@ def test_parse_tucan(tucan, expected_atoms, expected_bonds):
 )
 def test_roundtrip_molfile_graph_tucan_graph_tucan_graph(m):
     m_serialized = serialize_molecule(canonicalize_molecule(m))
-    g1 = parse_tucan(m_serialized)
+    g1 = graph_from_tucan(m_serialized)
     g1_serialized = serialize_molecule(canonicalize_molecule(g1.copy()))
-    g2 = parse_tucan(g1_serialized)
+    g2 = graph_from_tucan(g1_serialized)
 
     assert m_serialized == g1_serialized
     assert dict(g1.nodes(data=True)) == dict(g2.nodes(data=True))
@@ -241,7 +237,9 @@ def test_roundtrip_molfile_graph_tucan_graph_tucan_graph(m):
         ("CH3//(1:mass=13)(5:rad=3)", 5),
     ],
 )
-def test_parse_tucan_invalid_node_index_raises_exception(tucan, offending_node_index):
+def test_graph_from_tucan_invalid_node_index_raises_exception(
+    tucan, offending_node_index
+):
     expected_error_msg = f"^Atom with index {offending_node_index} does not exist.$"
     with pytest.raises(TucanParserException, match=expected_error_msg):
-        graph = parse_tucan(tucan)
+        graph = graph_from_tucan(tucan)

--- a/tucan/io/__init__.py
+++ b/tucan/io/__init__.py
@@ -1,0 +1,9 @@
+"""TUCAN IO package"""
+
+from tucan.io.molfile_reader import (
+    graph_from_file,
+    graph_from_molfile_text,
+    MolfileParserException,
+)
+
+from tucan.parser.parser import graph_from_tucan, TucanParserException

--- a/tucan/io/molfile_reader.py
+++ b/tucan/io/molfile_reader.py
@@ -1,9 +1,8 @@
-from collections import deque
 import networkx as nx
+from collections import deque
 from pathlib import Path
+from typing import List, Dict, Tuple
 from tucan.element_properties import ELEMENT_PROPS
-from tucan.parser.parser import parse_tucan
-from typing import Dict, List, Tuple
 
 
 def graph_from_file(filepath: str) -> nx.Graph:
@@ -34,21 +33,6 @@ def graph_from_file(filepath: str) -> nx.Graph:
 def graph_from_molfile_text(molfile: str) -> nx.Graph:
     lines = _split_into_tokenized_lines(molfile)
     return _graph_from_tokenized_lines(lines)
-
-
-def graph_from_tucan(tucan: str) -> nx.Graph:
-    """Instantiate a NetworkX graph from a TUCAN string.
-
-    Parameters
-    ----------
-    tucan: str
-        TUCAN string to be deserialized.
-
-    Returns
-    -------
-    NetworkX Graph
-    """
-    return parse_tucan()
 
 
 def _split_into_tokenized_lines(string: str) -> List[List[str]]:

--- a/tucan/parser/parser.py
+++ b/tucan/parser/parser.py
@@ -8,7 +8,18 @@ from tucan.parser.tucanListener import tucanListener
 from tucan.parser.tucanParser import tucanParser
 
 
-def parse_tucan(tucan: str) -> nx.Graph:
+def graph_from_tucan(tucan: str) -> nx.Graph:
+    """Instantiate a NetworkX graph from a TUCAN string.
+
+    Parameters
+    ----------
+    tucan: str
+        TUCAN string to be deserialized.
+
+    Returns
+    -------
+    NetworkX Graph
+    """
     parser = _prepare_parser(tucan)
     tree = parser.tucan()
     listener = _walk_tree(tree)


### PR DESCRIPTION
Follow-up from #75 

Existing imports of public functions from `tucan.io` are not broken.