### PR TITLE
Improve Molfile version validation

### DIFF
--- a/tucan/io/molfile_reader.py
+++ b/tucan/io/molfile_reader.py
@@ -91,7 +91,7 @@ def _graph_from_tokenized_lines(lines: list[list[str]]) -> nx.Graph:
 
 
 def _validate_molfile_version(lines: list[list[str]], expected_version: str):
-    if (version := lines[3][6]) != expected_version:
+    if (version := lines[3][-1]) != expected_version:
         raise MolfileParserException(
             f'Invalid Molfile version: Expected "{expected_version}", found "{version}"'
         )


### PR DESCRIPTION
I've seen the use of different numbers of tokens in Molfile header line 4 from some chemical structure editors.

Examples:
- Ketcher: `  0  0  0  0  0  0  0  0  0  0  0 V3000`
- OpenChemLib: `  0  0  0  0  0  0              0 V3000`

This change makes our Molfile reader less susceptible for this.