### PR TITLE
graph_from_pubchem()

### DIFF
--- a/tucan/io/graph_from_pubchem.py
+++ b/tucan/io/graph_from_pubchem.py
@@ -1,0 +1,68 @@
+
+import networkx as nx
+import pubchempy as pcp
+
+from tucan.element_properties import ELEMENT_PROPS
+
+def graph_from_pubchem(cid: int) -> nx.Graph:
+    """Instantiate a NetworkX graph from a PubChem entry.
+    Parameters
+    ----------
+    cid: int
+        Non-zero integer number pointing to a PubChem entry [1].
+    Returns
+    -------
+    NetworkX Graph
+    References
+    ----------
+    [1] https://pubchempy.readthedocs.io
+    """
+
+    if(cid < 1):
+        raise PubChemParserException(
+            f'Invalid Compound ID (CID) "{cid}"'
+        )
+
+    c = pcp.Compound.from_cid(cid)
+
+    atoms = c.to_dict(properties=['atoms'])
+    bonds = c.to_dict(properties=['bonds'])
+
+    m = nx.Graph()
+
+    for atom in atoms["atoms"]:
+        keys = atom.keys()
+        for k in keys:
+            if(k == "aid"):
+                atom1 = atom[k]
+            elif(k == "number"):
+                atomic_number = atom[k]
+            elif(k == "element"):
+                element_symbol = atom[k]
+            elif(k == "x"):
+                xcoord = atom[k]
+            elif(k == "y"):
+                ycoord = atom[k]
+        zcoord = 0
+        m.add_node(int(atom1))
+        attrs = {atom1: {"node_label": atom1, "atomic_number": atomic_number, "partition": 0, "element_symbol": element_symbol, "element_color": (208,208,224),
+                         "x_coord": float(xcoord), "y_coord": float(ycoord), "z_coord": float(zcoord)
+                        }
+                }
+        nx.set_node_attributes(m, attrs)
+
+    for bond in bonds["bonds"]:
+        keys = bond.keys()
+        for k in keys:
+            if(k == "aid1"):
+                atom1 = bond[k]
+            elif(k == "aid2"):
+                atom2 = bond[k]
+            elif(k == "order"):
+                bond_order = bond[k]
+        m.add_edge(int(atom1), int(atom2))
+
+    return m
+
+class PubChemParserException(Exception):
+    pass


### PR DESCRIPTION
The graph_from_pubchem() routine generates a NetworkX graph by directly querying PubChem for a particular compound ID (CID) without a detour via a molfile

Requires network connection

So far tested on a couple of hundred random-selected PubChem entries

Needs more checks for input validity:

- Currently only checks if CID > 0 but not if CID is within upper limit
- Assumes that bonds and atoms read form a valid graph and all required node attributes are included
- Does not assign element_color according to Jmol definitions so far